### PR TITLE
Add travis ci build and provide readme 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,53 @@
+language: ruby
+
+sudo: true
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode10
+      rvm: system
+  fast_finish: true
+
+branches:
+  only:
+    - master
+
+cache:
+  directories:
+    - /usr/local/Homebrew/Library/Homebrew/vendor/bundle
+    - /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby
+
+install:
+  - |
+    # Force strict error checking.
+    set -o errexit
+    set -o pipefail
+  - |
+    # Update Travis commit range.
+    # This is not normally required but does prevent problems with outdated forks and
+    # deleted casks (see https://github.com/Homebrew/homebrew-cask/pull/43164).
+    BRANCH_COMMIT="${TRAVIS_COMMIT_RANGE##*.}"
+    TARGET_COMMIT="${TRAVIS_COMMIT_RANGE%%.*}"
+    if ! MERGE_BASE="$(git merge-base "${BRANCH_COMMIT}" "${TARGET_COMMIT}" 2>/dev/null)"; then
+      git fetch --unshallow
+      MERGE_BASE="$(git merge-base "${BRANCH_COMMIT}" "${TARGET_COMMIT}")"
+    fi
+    export TRAVIS_COMMIT_RANGE="${MERGE_BASE}...${BRANCH_COMMIT}"
+  - |
+    # Switch to master branch.
+    export HOMEBREW_COLOR=1
+    export HOMEBREW_DEVELOPER=1
+    export HOMEBREW_NO_AUTO_UPDATE=1
+    brew update
+  - |
+    # Mirror the repo as a tap.
+    TAP_DIR="$(brew --repository)/Library/Taps/${TRAVIS_REPO_SLUG}"
+    mkdir -p "${TAP_DIR}"
+    rsync -az --delete "${TRAVIS_BUILD_DIR}/" "${TAP_DIR}/"
+    export TRAVIS_BUILD_DIR="${TAP_DIR}"
+    builtin cd "${TRAVIS_BUILD_DIR}"
+script: brew cask ci
+
+notifications:
+email: false

--- a/Casks/yahoo-keykey.rb
+++ b/Casks/yahoo-keykey.rb
@@ -4,7 +4,7 @@ cask 'yahoo-keykey' do
 
   url "https://github.com/Yi-Kai/YahooKeyKey/releases/download/v#{version}/YahooKeyKey.zip"
   appcast 'https://github.com/Yi-Kai/YahooKeyKey/releases.atom'
-  name 'Yahoo! KeyKey Chinese input method (ci-test)'
+  name 'Yahoo! KeyKey Chinese input method engine (IME)'
   homepage 'https://github.com/Yi-Kai/YahooKeyKey'
 
   pkg 'KeyKey.pkg'

--- a/Casks/yahoo-keykey.rb
+++ b/Casks/yahoo-keykey.rb
@@ -4,7 +4,7 @@ cask 'yahoo-keykey' do
 
   url "https://github.com/Yi-Kai/YahooKeyKey/releases/download/v#{version}/YahooKeyKey.zip"
   appcast 'https://github.com/Yi-Kai/YahooKeyKey/releases.atom'
-  name 'Yahoo! KeyKey Chinese input method'
+  name 'Yahoo! KeyKey Chinese input method (ci-test)'
   homepage 'https://github.com/Yi-Kai/YahooKeyKey'
 
   pkg 'KeyKey.pkg'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/Yi-Kai/homebrew-yahoo-keykey.svg?branch=master)](https://travis-ci.org/Yi-Kai/homebrew-yahoo-keykey)
 
-> Yahoo! KeyKey Chinese input method for Homebrew Tap
+> Brew tap for Yahoo! KeyKey Chinese input method
 
 # How to Use
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/Yi-Kai/homebrew-yahoo-keykey.svg?branch=master)](https://travis-ci.org/Yi-Kai/homebrew-yahoo-keykey)
 
-> Brew tap for Yahoo! KeyKey Chinese input method
+> Brew tap for Yahoo! KeyKey Chinese input method engine (IME)
 
 # How to Use
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # homebrew-yahoo-keykey
 
-[![Build Status](https://travis-ci.org/scw1109/homebrew-yahoo-keykey.svg?branch=master)](https://travis-ci.org/scw1109/homebrew-yahoo-keykey)
+[![Build Status](https://travis-ci.org/Yi-Kai/homebrew-yahoo-keykey.svg?branch=master)](https://travis-ci.org/Yi-Kai/homebrew-yahoo-keykey)
 
 > Yahoo! KeyKey Chinese input method for Homebrew Tap
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # homebrew-yahoo-keykey
+
 Yahoo! KeyKey Chinese input method for Homebrew Tap
+
+[![Build Status](https://travis-ci.org/scw1109/homebrew-yahoo-keykey.svg?branch=master)](https://travis-ci.org/scw1109/homebrew-yahoo-keykey)
+
+# How to Use
+
+## Prerequisite
+
+ * Install [Homebrew](https://brew.sh/) (see installation guide in [Chinese](https://brew.sh/index_zh-tw), [English](https://brew.sh/) )
+
+## Install
+
+```bash
+brew tap Yi-Kai/yahoo-keykey
+brew cask install yahoo-keykey 
+```
+
+## Uninstall
+
+```bash
+brew cask uninstall yahoo-keykey
+```
+
+# See also
+
+ * [Yahoo Keykey](https://github.com/Yi-Kai/YahooKeyKey)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # homebrew-yahoo-keykey
 
-Yahoo! KeyKey Chinese input method for Homebrew Tap
-
 [![Build Status](https://travis-ci.org/scw1109/homebrew-yahoo-keykey.svg?branch=master)](https://travis-ci.org/scw1109/homebrew-yahoo-keykey)
+
+> Yahoo! KeyKey Chinese input method for Homebrew Tap
 
 # How to Use
 
 ## Prerequisite
 
- * Install [Homebrew](https://brew.sh/) (see installation guide in [Chinese](https://brew.sh/index_zh-tw), [English](https://brew.sh/) )
+ * Install [Homebrew](https://brew.sh/) (see installation guide in [Chinese](https://brew.sh/index_zh-tw) or [English](https://brew.sh/) )
 
 ## Install
 


### PR DESCRIPTION
In order to make this work, please follow these [steps](https://docs.travis-ci.com/user/tutorial/#to-get-started-with-travis-ci) to activate Travis CI build after merge. (`.travis.yml` is already provided in this change)

Also, please use "Squash and merge" when merging this item. 

Notify @Yi-Kai 