### PR TITLE
livecheck instead of appcast

### DIFF
--- a/Casks/yahoo-keykey.rb
+++ b/Casks/yahoo-keykey.rb
@@ -3,7 +3,7 @@ cask 'yahoo-keykey' do
   sha256 'affa3836cc1737e8a42bdb64d70e141979a1284055c30e27f253b38f54109404'
 
   url "https://github.com/Yi-Kai/YahooKeyKey/releases/download/v#{version}/YahooKeyKey.zip"
-  appcast 'https://github.com/Yi-Kai/YahooKeyKey/releases.atom'
+  livecheck 'https://github.com/Yi-Kai/YahooKeyKey/releases.atom'
   name 'Yahoo! KeyKey Chinese input method engine (IME)'
   homepage 'https://github.com/Yi-Kai/YahooKeyKey'
 


### PR DESCRIPTION
> Error: Cask 'yahoo-keykey' definition is invalid: 'appcast' stanza failed with: Calling the `appcast` stanza is disabled! Use the `livecheck` stanza instead.
Please report this issue to the yi-kai/yahoo-keykey tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/yi-kai/homebrew-yahoo-keykey/Casks/yahoo-keykey.rb:6
